### PR TITLE
Fix left/right to L/R in rpioperant

### DIFF
--- a/behav/loading.py
+++ b/behav/loading.py
@@ -8,6 +8,7 @@ import os
 import warnings
 from six.moves import range
 
+
 def load_data_pandas(subjects, data_folder, force_boolean=['reward']):
     '''
     a function that loads data files for a number of subjects into panda DataFrames.
@@ -161,8 +162,8 @@ def load_data_pandas(subjects, data_folder, force_boolean=['reward']):
                     df_set[broken_df].index = [_validate_time(i,"%Y-%m-%d %H:%M:%S.%f") for i in df_set[broken_df].index]
                     df_set[broken_df] = df_set[broken_df][df_set[broken_df].index != False]
                     df_set[broken_df].index = pd.to_datetime(df_set[broken_df].index)
-
-            behav_data[subj] = pd.concat(df_set).sort_index()
+    
+            behav_data[subj] = _leftright_to_LR(pd.concat(df_set).sort_index())
         else:
             print('data not found for %s' % (subj))
     if force_boolean:
@@ -182,3 +183,12 @@ def _read_year_rDAT(rDat_f, nheaderrows):
         head = [next(f) for x in range(nheaderrows)]
     date_line = [x for x in head if 'Start time' in x]
     return int(date_line[0][-5:-1])
+
+
+def _leftright_to_LR(data):
+    """ converts the response column 'left' to 'L' and 'right' to 'R'
+    to remain consistent with older versions of pyoperant
+    """
+    data.loc[data['response'].values == 'left', 'response'] = 'L'
+    data.loc[data['response'].values == 'right', 'response'] = 'R'
+    return data

--- a/behav/loading.py
+++ b/behav/loading.py
@@ -185,12 +185,3 @@ def _read_year_rDAT(rDat_f, nheaderrows):
         head = [next(f) for x in range(nheaderrows)]
     date_line = [x for x in head if 'Start time' in x]
     return int(date_line[0][-5:-1])
-
-
-def _leftright_to_LR(data):
-    """ converts the response column 'left' to 'L' and 'right' to 'R'
-    to remain consistent with older versions of pyoperant
-    """
-    data.loc[data['response'].values == 'left', 'response'] = 'L'
-    data.loc[data['response'].values == 'right', 'response'] = 'R'
-    return data

--- a/behav/loading.py
+++ b/behav/loading.py
@@ -162,8 +162,10 @@ def load_data_pandas(subjects, data_folder, force_boolean=['reward']):
                     df_set[broken_df].index = [_validate_time(i,"%Y-%m-%d %H:%M:%S.%f") for i in df_set[broken_df].index]
                     df_set[broken_df] = df_set[broken_df][df_set[broken_df].index != False]
                     df_set[broken_df].index = pd.to_datetime(df_set[broken_df].index)
-    
-            behav_data[subj] = _leftright_to_LR(pd.concat(df_set).sort_index())
+            
+            # concatenate data and remap response left/right to L/R
+            df = pd.concat(df_set).sort_index()['response'].map({'left':'L', 'right':'R'})
+            behav_data[subj] = df
         else:
             print('data not found for %s' % (subj))
     if force_boolean:

--- a/behav/plotting.py
+++ b/behav/plotting.py
@@ -229,7 +229,6 @@ def plot_accuracy_bias(subj, df, x_axis='time', smoothing='exponential', trial_l
         use_index = False
     else:
         raise Exception('invalid value for x_axis')
-
     datas = (df['correct'].astype(float), df['response'] == 'L', df['response'] == 'R')
     plot_smoothed_mask = (plt_correct_smoothed, plt_L_response_smoothed, plt_R_response_smoothed)
     plot_shaded_mask = (plt_correct_shade, plt_L_response_shade, plt_R_response_shade)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='behav-analysis',


### PR DESCRIPTION
RPiOperant version of pyoperant uses 'response' values of 'left' rather than 'L' in previous versions. 